### PR TITLE
Add missing ruby citation_text

### DIFF
--- a/src/processors/utils/treeprocessor.ts
+++ b/src/processors/utils/treeprocessor.ts
@@ -223,8 +223,13 @@ class TreeProcessor {
             this.citations.push(bib_key);
           }
           if (bib_key in this.biblio) {
-            // TODO: implement ruby citation_text
-            v = `[${this.citations.indexOf(bib_key) + 1}]`;
+            const cite = new Cite().set(this.biblio[bib_key]);
+            cite.options({ style: "csl" });
+            const formatted = cite.format("citation", {
+              template: this.style,
+              lang: this.locale
+            });
+            v = formatted || `[${this.citations.indexOf(bib_key) + 1}]`;
           } else {
             const error_message = `Unknown bibliography reference: ${bib_key}`;
             if (this.throw_on_unknown) {


### PR DESCRIPTION
The :bibtex-style: was applied to the bibliography overview, but not to the citations within the text itself. Meaning the citations within the text were always numeric even when a different citation style was selected.

I used AI to generate this and tested it only with a single bibtex-style option, but it did work for my use case. I did not test it further. I hope it's useful for others too.